### PR TITLE
objects_maker.py: make_organism_creators()

### DIFF
--- a/gasp/objects_maker.py
+++ b/gasp/objects_maker.py
@@ -351,14 +351,6 @@ def make_organism_creators(parameters, composition_space, constraints):
                                     endpoint.reduced_composition) and \
                                     endpoint not in provided_endpoints:
                                 provided_endpoints.append(endpoint)
-                    # check if we got them all
-                    for endpoint in composition_space.endpoints:
-                        if endpoint not in provided_endpoints:
-                            print('Error: valid structure files not provided '
-                                  'to the initial population for all '
-                                  'endpoints of the composition space.')
-                            print('Quitting...')
-                            quit()
                 initial_organism_creators.append(files_organism_creator)
 
         # TODO: if other organism creators are used, they should be


### PR DESCRIPTION
I learned about the GASP code at an IPAM workshop and I currently try to feed random clusters with specific space groups, like the ones generated from https://github.com/psavery/randSpg to GASP. This means I do not have the whole configuration range included in my input data therefore I removed the corresponding check. Or is there a particular reason to keep it? 

Best regards 

Jan